### PR TITLE
feat: ブログ記事にシェアボタン機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "astro": "^5.12.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-share": "^5.2.2",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.2.2"
       },
@@ -3091,6 +3092,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -4571,6 +4578,29 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "license": "MIT"
+    },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/kleur": {
@@ -6403,6 +6433,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-share": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.2.2.tgz",
+      "integrity": "sha512-z0nbOX6X6vHHWAvXduNkYeJUKTKNpKM5Xpmc5a2BxjJhUWl+sE7AsSEMmYEUj2DuDjZr5m7KFIGF0sQPKcUN6w==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "jsonp": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "astro": "^5.12.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-share": "^5.2.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.2.2"
   },

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import {
+  TwitterShareButton,
+  FacebookShareButton,
+  LineShareButton,
+  TwitterIcon,
+  FacebookIcon,
+  LineIcon,
+} from 'react-share';
+
+interface ShareButtonsProps {
+  url: string;
+  title: string;
+}
+
+export default function ShareButtons({ url, title }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
+  const handleHatenaShare = () => {
+    const hatenaUrl = `https://b.hatena.ne.jp/entry/panel/?url=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`;
+    window.open(hatenaUrl, '_blank', 'width=500,height=500');
+  };
+
+  return (
+    <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">
+        📤 この記事をシェア
+      </h3>
+      <div className="flex flex-wrap gap-3">
+        {/* Twitter */}
+        <TwitterShareButton url={url} title={title}>
+          <div className="flex items-center gap-2 px-3 py-2 bg-black hover:bg-gray-800 text-white rounded-lg transition-colors group">
+            <TwitterIcon size={20} round />
+            <span className="text-sm font-medium">Twitter</span>
+          </div>
+        </TwitterShareButton>
+
+        {/* Facebook */}
+        <FacebookShareButton url={url}>
+          <div className="flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors group">
+            <FacebookIcon size={20} round />
+            <span className="text-sm font-medium">Facebook</span>
+          </div>
+        </FacebookShareButton>
+
+        {/* はてなブックマーク */}
+        <button
+          onClick={handleHatenaShare}
+          className="flex items-center gap-2 px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors"
+          aria-label="はてなブックマークでシェア"
+        >
+          <div className="w-5 h-5 bg-white rounded-full flex items-center justify-center">
+            <span className="text-blue-500 text-xs font-bold">B!</span>
+          </div>
+          <span className="text-sm font-medium">はてブ</span>
+        </button>
+
+        {/* LINE */}
+        <LineShareButton url={url} title={title}>
+          <div className="flex items-center gap-2 px-3 py-2 bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors group">
+            <LineIcon size={20} round />
+            <span className="text-sm font-medium">LINE</span>
+          </div>
+        </LineShareButton>
+
+        {/* リンクコピー */}
+        <button
+          onClick={handleCopyLink}
+          className="flex items-center gap-2 px-3 py-2 bg-gray-500 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-lg transition-colors"
+          aria-label="リンクをコピー"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+            />
+          </svg>
+          <span className="text-sm font-medium">
+            {copied ? 'コピー済み!' : 'リンクコピー'}
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -32,55 +32,56 @@ export default function ShareButtons({ url, title }: ShareButtonsProps) {
   };
 
   return (
-    <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">
-        📤 この記事をシェア
-      </h3>
-      <div className="flex flex-wrap gap-3">
-        {/* Twitter */}
+    <div className="mt-8 pt-4">
+      <div className="flex items-center justify-center gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 mr-2">Share:</span>
+        
+        {/* X (Twitter) */}
         <TwitterShareButton url={url} title={title}>
-          <div className="flex items-center gap-2 px-3 py-2 bg-black hover:bg-gray-800 text-white rounded-lg transition-colors group">
-            <TwitterIcon size={20} round />
-            <span className="text-sm font-medium">Twitter</span>
+          <div className="p-1 text-gray-600 hover:text-black dark:text-gray-400 dark:hover:text-white transition-all duration-200 hover:scale-110" title="X でシェア">
+            <div className="w-6 h-6 bg-current rounded-full flex items-center justify-center">
+              <svg className="w-3 h-3 fill-white" viewBox="0 0 24 24">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+              </svg>
+            </div>
           </div>
         </TwitterShareButton>
 
         {/* Facebook */}
         <FacebookShareButton url={url}>
-          <div className="flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors group">
-            <FacebookIcon size={20} round />
-            <span className="text-sm font-medium">Facebook</span>
+          <div className="p-1 text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400 transition-all duration-200 hover:scale-110" title="Facebook でシェア">
+            <FacebookIcon size={24} round />
           </div>
         </FacebookShareButton>
 
         {/* はてなブックマーク */}
         <button
           onClick={handleHatenaShare}
-          className="flex items-center gap-2 px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors"
+          className="p-1 text-gray-600 hover:text-blue-500 dark:text-gray-400 dark:hover:text-blue-400 transition-all duration-200 hover:scale-110"
           aria-label="はてなブックマークでシェア"
+          title="はてなブックマーク でシェア"
         >
-          <div className="w-5 h-5 bg-white rounded-full flex items-center justify-center">
-            <span className="text-blue-500 text-xs font-bold">B!</span>
+          <div className="w-6 h-6 bg-current rounded-full flex items-center justify-center">
+            <span className="text-white text-xs font-bold">B!</span>
           </div>
-          <span className="text-sm font-medium">はてブ</span>
         </button>
 
         {/* LINE */}
         <LineShareButton url={url} title={title}>
-          <div className="flex items-center gap-2 px-3 py-2 bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors group">
-            <LineIcon size={20} round />
-            <span className="text-sm font-medium">LINE</span>
+          <div className="p-1 text-gray-600 hover:text-green-500 dark:text-gray-400 dark:hover:text-green-400 transition-all duration-200 hover:scale-110" title="LINE でシェア">
+            <LineIcon size={24} round />
           </div>
         </LineShareButton>
 
         {/* リンクコピー */}
         <button
           onClick={handleCopyLink}
-          className="flex items-center gap-2 px-3 py-2 bg-gray-500 hover:bg-gray-600 dark:bg-gray-600 dark:hover:bg-gray-700 text-white rounded-lg transition-colors"
+          className="p-1 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 transition-all duration-200 hover:scale-110"
           aria-label="リンクをコピー"
+          title={copied ? 'コピー済み!' : 'リンクをコピー'}
         >
           <svg
-            className="w-5 h-5"
+            className="w-6 h-6"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -92,9 +93,6 @@ export default function ShareButtons({ url, title }: ShareButtonsProps) {
               d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
             />
           </svg>
-          <span className="text-sm font-medium">
-            {copied ? 'コピー済み!' : 'リンクコピー'}
-          </span>
         </button>
       </div>
     </div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import FormattedDate from "../components/FormattedDate.astro";
+import ShareButtons from "../components/ShareButtons.tsx";
 import type { PaginationData } from "../utils/pagination";
 import "@fontsource/josefin-sans";
 
@@ -10,6 +11,7 @@ type Props = CollectionEntry<"blog">["data"] & {
 };
 
 const { title, description, pubDate, updatedDate, tags, pagination } = Astro.props;
+const currentUrl = Astro.url.href;
 ---
 
 <BaseLayout title={title} description={description}>
@@ -50,6 +52,8 @@ const { title, description, pubDate, updatedDate, tags, pagination } = Astro.pro
 		</div>
 		<slot />
 	</article>
+	
+	<ShareButtons url={currentUrl} title={title} client:load />
 	
 	{pagination && (
 		<nav class="mt-8 pt-8 border-t border-gray-200 dark:border-gray-700" aria-label="記事ナビゲーション">


### PR DESCRIPTION
## Summary
- ブログ記事にソーシャルメディアシェア機能を追加
- Issue #15 の要求事項に対応

## Changes
- **react-shareライブラリ追加**: X、Facebook、LINE対応
- **ShareButtonsコンポーネント作成**: `src/components/ShareButtons.tsx`
- **PostLayoutに統合**: すべての記事ページでシェア機能利用可能
- **対応プラットフォーム**:
  - X (旧Twitter) - 公式Xロゴ使用
  - Facebook
  - はてなブックマーク (カスタム実装)
  - LINE
  - リンクコピー (クリップボードAPI)

## Design Features
- 控えめなアイコンのみのデザイン
- ダークモード対応
- ホバー時のスケールエフェクト(110%)
- レスポンシブ対応
- アクセシビリティ配慮(tooltip、aria-label)

## Test Plan
- [x] 各シェアボタンの動作確認
- [x] ダークモード表示確認
- [x] レスポンシブデザイン確認
- [x] ビルドエラーなし確認

🤖 Generated with [Claude Code](https://claude.ai/code)