### PR TITLE
feat: コンテンツ管理システムとプロフィールUI改善（Phase 2）

### DIFF
--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -1,9 +1,26 @@
 ---
+import { getCollection } from "astro:content";
+
 interface Props {
   variant?: 'full' | 'compact';
 }
 
 const { variant = 'full' } = Astro.props;
+
+// プロフィールデータを取得
+const profileEntries = await getCollection('profile');
+const profileData = profileEntries[0]?.data;
+
+// スキルをカテゴリ別に色分け
+const getSkillColor = (category: string) => {
+  const colors = {
+    language: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200',
+    framework: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
+    cms: 'bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200',
+    styling: 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-200',
+  };
+  return colors[category as keyof typeof colors] || 'bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200';
+};
 ---
 
 <div class={`profile-card ${variant === 'compact' ? 'p-6' : 'p-8'} bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700`}>
@@ -11,8 +28,8 @@ const { variant = 'full' } = Astro.props;
   <div class="flex items-center space-x-4 mb-6">
     <div class="relative">
       <img 
-        src="/images/avatar.png" 
-        alt="大嶋大輝のプロフィール画像" 
+        src={profileData?.avatar || "/images/avatar.png"}
+        alt={`${profileData?.name || '大嶋大輝'}のプロフィール画像`}
         class={`rounded-full object-cover border-2 border-gray-200 dark:border-gray-600 ${variant === 'compact' ? 'w-16 h-16' : 'w-24 h-24'}`}
         width={variant === 'compact' ? 64 : 96}
         height={variant === 'compact' ? 64 : 96}
@@ -21,12 +38,12 @@ const { variant = 'full' } = Astro.props;
     </div>
     
     <div class="flex-1">
-      <h3 class="text-xl font-bold text-gray-900 dark:text-white">大嶋大輝</h3>
-      <p class="text-gray-600 dark:text-gray-300">Frontend Engineer</p>
+      <h3 class="text-xl font-bold text-gray-900 dark:text-white">{profileData?.name || '大嶋大輝'}</h3>
+      <p class="text-gray-600 dark:text-gray-300">{profileData?.title || 'Frontend Engineer'}</p>
       {variant === 'full' && (
         <div class="flex items-center space-x-2 mt-1">
-          <span class="text-sm text-gray-500 dark:text-gray-400">📍 Japan</span>
-          <span class="text-sm text-green-500">● Available</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">📍 {profileData?.location || 'Japan'}</span>
+          <span class="text-sm text-green-500">● {profileData?.availability || 'Available'}</span>
         </div>
       )}
     </div>
@@ -36,29 +53,25 @@ const { variant = 'full' } = Astro.props;
   <div class="mb-6">
     {variant === 'compact' ? (
       <p class="text-sm text-gray-600 dark:text-gray-300">
-        フロントエンドエンジニア。WordPress Developer として業務に従事し、個人では Next.js や Astro などのモダンな技術に取り組んでいます。
+        {profileData?.bio?.slice(0, 100) || 'フロントエンドエンジニア。WordPress Developer として業務に従事し、個人では Next.js や Astro などのモダンな技術に取り組んでいます。'}...
       </p>
     ) : (
       <p class="text-gray-600 dark:text-gray-300">
-        当サイトをご覧いただきありがとうございます。フロントエンドエンジニアとして活動している大嶋大輝です。
-        業務では WordPress Developer として働き、個人では Next.js や Astro などのモダンな Web 技術に取り組んでいます。
-        趣味は読書で、技術書からビジネス書まで幅広く読んでいます。
+        {profileData?.bio || '当サイトをご覧いただきありがとうございます。フロントエンドエンジニアとして活動している大嶋大輝です。業務では WordPress Developer として働き、個人では Next.js や Astro などのモダンな Web 技術に取り組んでいます。趣味は読書で、技術書からビジネス書まで幅広く読んでいます。'}
       </p>
     )}
   </div>
 
   <!-- スキル（full版のみ） -->
-  {variant === 'full' && (
+  {variant === 'full' && profileData?.skills && (
     <div class="mb-6">
       <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-3">Tech Stack</h4>
       <div class="flex flex-wrap gap-2">
-        <span class="px-3 py-1 text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full">JavaScript</span>
-        <span class="px-3 py-1 text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full">TypeScript</span>
-        <span class="px-3 py-1 text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full">React</span>
-        <span class="px-3 py-1 text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full">Next.js</span>
-        <span class="px-3 py-1 text-xs font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded-full">Astro</span>
-        <span class="px-3 py-1 text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 rounded-full">WordPress</span>
-        <span class="px-3 py-1 text-xs font-medium bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-200 rounded-full">TailwindCSS</span>
+        {profileData.skills.map((skill) => (
+          <span class={`px-3 py-1 text-xs font-medium rounded-full ${getSkillColor(skill.category)}`}>
+            {skill.name}
+          </span>
+        ))}
       </div>
     </div>
   )}

--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -23,9 +23,9 @@ const getSkillColor = (category: string) => {
 };
 ---
 
-<div class={`profile-card ${variant === 'compact' ? 'p-6' : 'p-8'} bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700`}>
+<div class={`profile-card ${variant === 'compact' ? 'p-4' : 'p-8'} bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700`}>
   <!-- アバター部分 -->
-  <div class="flex items-center space-x-4 mb-6">
+  <div class="flex items-center space-x-3 mb-4">
     <div class="relative">
       <img 
         src={profileData?.avatar || "/images/avatar.png"}
@@ -34,29 +34,27 @@ const getSkillColor = (category: string) => {
         width={variant === 'compact' ? 64 : 96}
         height={variant === 'compact' ? 64 : 96}
       />
-      <div class="absolute -bottom-1 -right-1 w-6 h-6 bg-green-400 border-2 border-white dark:border-gray-800 rounded-full"></div>
     </div>
     
     <div class="flex-1">
-      <h3 class="text-xl font-bold text-gray-900 dark:text-white">{profileData?.name || '大嶋大輝'}</h3>
-      <p class="text-gray-600 dark:text-gray-300">{profileData?.title || 'Frontend Engineer'}</p>
+      <h3 class="text-lg font-bold text-gray-900 dark:text-white">{profileData?.name || '大嶋大輝'}</h3>
+      <p class="text-sm text-gray-600 dark:text-gray-300 font-['Josefin_Sans']">{profileData?.title || 'Software Engineer'}</p>
       {variant === 'full' && (
         <div class="flex items-center space-x-2 mt-1">
-          <span class="text-sm text-gray-500 dark:text-gray-400">📍 {profileData?.location || 'Japan'}</span>
-          <span class="text-sm text-green-500">● {profileData?.availability || 'Available'}</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400 font-['Josefin_Sans']">📍 {profileData?.location || 'Japan'}</span>
         </div>
       )}
     </div>
   </div>
 
   <!-- 自己紹介 -->
-  <div class="mb-6">
+  <div class="mb-4">
     {variant === 'compact' ? (
-      <p class="text-sm text-gray-600 dark:text-gray-300">
-        {profileData?.bio?.slice(0, 100) || 'フロントエンドエンジニア。WordPress Developer として業務に従事し、個人では Next.js や Astro などのモダンな技術に取り組んでいます。'}...
+      <p class="text-xs text-gray-600 dark:text-gray-300">
+        {profileData?.bio || 'フロントエンドエンジニア。WordPress Developer として業務に従事し、個人では Next.js や Astro などのモダンな技術に取り組んでいます。'}
       </p>
     ) : (
-      <p class="text-gray-600 dark:text-gray-300">
+      <p class="text-sm text-gray-600 dark:text-gray-300">
         {profileData?.bio || '当サイトをご覧いただきありがとうございます。フロントエンドエンジニアとして活動している大嶋大輝です。業務では WordPress Developer として働き、個人では Next.js や Astro などのモダンな Web 技術に取り組んでいます。趣味は読書で、技術書からビジネス書まで幅広く読んでいます。'}
       </p>
     )}
@@ -65,10 +63,10 @@ const getSkillColor = (category: string) => {
   <!-- スキル（full版のみ） -->
   {variant === 'full' && profileData?.skills && (
     <div class="mb-6">
-      <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-3">Tech Stack</h4>
+      <h4 class="text-xs font-semibold text-gray-900 dark:text-white mb-3 font-['Josefin_Sans']">Tech Stack</h4>
       <div class="flex flex-wrap gap-2">
         {profileData.skills.map((skill) => (
-          <span class={`px-3 py-1 text-xs font-medium rounded-full ${getSkillColor(skill.category)}`}>
+          <span class={`px-2 py-0.5 text-xs font-medium rounded-full ${getSkillColor(skill.category)}`}>
             {skill.name}
           </span>
         ))}
@@ -77,10 +75,10 @@ const getSkillColor = (category: string) => {
   )}
 
   {variant === 'compact' && (
-    <div class="mt-4 text-center">
+    <div class="mt-3 text-center">
       <a 
         href="/profile" 
-        class="inline-flex items-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+        class="inline-flex items-center text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
       >
         詳しいプロフィールを見る
         <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -1,0 +1,40 @@
+---
+import { getCollection } from "astro:content";
+
+// プロフィールデータを取得
+const profileEntries = await getCollection('profile');
+const timelineData = profileEntries[0]?.data?.timeline || [];
+---
+
+<div class="prose max-w-full dark:prose-invert">
+  <h2>Career Timeline</h2>
+  <hr>
+  <ol class="list-none relative border-l border-gray-300">
+    {timelineData.map((item) => (
+      <li class="mb-8 -ml-2">
+        <div class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"></div>
+        <time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
+          {item.date}
+        </time>
+        {item.title && (
+          <h5>{item.title}</h5>
+        )}
+        {item.description && (
+          <p class={`text-sm text-gray-600 ${item.link ? 'mb-4' : ''}`}>
+            {item.description}
+          </p>
+        )}
+        {item.link && (
+          <a
+            href={item.link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-normal"
+          >
+            {item.link.text}
+          </a>
+        )}
+      </li>
+    ))}
+  </ol>
+</div>

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -7,7 +7,7 @@ const timelineData = profileEntries[0]?.data?.timeline || [];
 ---
 
 <div class="prose max-w-full dark:prose-invert">
-  <h2>Career Timeline</h2>
+  <h2 class="font-['Josefin_Sans'] font-normal mb-2">Career Timeline</h2>
   <hr>
   <ol class="list-none relative border-l border-gray-300">
     {timelineData.map((item) => (

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,4 +13,32 @@ const blogCollection = defineCollection({
 	}),
 });
 
-export const collections = { blog: blogCollection };
+const profileCollection = defineCollection({
+	type: 'content',
+	schema: z.object({
+		name: z.string(),
+		title: z.string(),
+		location: z.string(),
+		availability: z.string(),
+		avatar: z.string(),
+		bio: z.string(),
+		skills: z.array(z.object({
+			name: z.string(),
+			category: z.string(),
+		})),
+		timeline: z.array(z.object({
+			date: z.string(),
+			title: z.string(),
+			description: z.string(),
+			link: z.object({
+				url: z.string(),
+				text: z.string(),
+			}).optional(),
+		})),
+	}),
+});
+
+export const collections = { 
+	blog: blogCollection,
+	profile: profileCollection 
+};

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,44 +1,49 @@
 import { defineCollection, z } from "astro:content";
 
 const blogCollection = defineCollection({
-	type: 'content',
-	// Type-check frontmatter using a schema
-	schema: z.object({
-		title: z.string(),
-		description: z.string(),
-		tags: z.array(z.string()).optional(),
-		// Transform string to Date object
-		pubDate: z.coerce.date(),
-		updatedDate: z.coerce.date().optional(),
-	}),
+  type: "content",
+  // Type-check frontmatter using a schema
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    tags: z.array(z.string()).optional(),
+    // Transform string to Date object
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+  }),
 });
 
 const profileCollection = defineCollection({
-	type: 'content',
-	schema: z.object({
-		name: z.string(),
-		title: z.string(),
-		location: z.string(),
-		availability: z.string(),
-		avatar: z.string(),
-		bio: z.string(),
-		skills: z.array(z.object({
-			name: z.string(),
-			category: z.string(),
-		})),
-		timeline: z.array(z.object({
-			date: z.string(),
-			title: z.string(),
-			description: z.string(),
-			link: z.object({
-				url: z.string(),
-				text: z.string(),
-			}).optional(),
-		})),
-	}),
+  type: "content",
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    location: z.string(),
+    avatar: z.string(),
+    bio: z.string(),
+    skills: z.array(
+      z.object({
+        name: z.string(),
+        category: z.string(),
+      })
+    ),
+    timeline: z.array(
+      z.object({
+        date: z.string(),
+        title: z.string(),
+        description: z.string(),
+        link: z
+          .object({
+            url: z.string(),
+            text: z.string(),
+          })
+          .optional(),
+      })
+    ),
+  }),
 });
 
-export const collections = { 
-	blog: blogCollection,
-	profile: profileCollection 
+export const collections = {
+  blog: blogCollection,
+  profile: profileCollection,
 };

--- a/src/content/profile/main.md
+++ b/src/content/profile/main.md
@@ -1,0 +1,53 @@
+---
+name: "大嶋大輝"
+title: "Frontend Engineer"
+location: "Japan"
+availability: "Available"
+avatar: "/images/avatar.png"
+bio: "当サイトをご覧いただきありがとうございます。フロントエンドエンジニアとして活動している大嶋大輝です。業務では WordPress Developer として働き、個人では Next.js や Astro などのモダンな Web 技術に取り組んでいます。趣味は読書で、技術書からビジネス書まで幅広く読んでいます。"
+skills:
+  - name: "JavaScript"
+    category: "language"
+  - name: "TypeScript"
+    category: "language"
+  - name: "React"
+    category: "framework"
+  - name: "Next.js"
+    category: "framework"
+  - name: "Astro"
+    category: "framework"
+  - name: "WordPress"
+    category: "cms"
+  - name: "TailwindCSS"
+    category: "styling"
+timeline:
+  - date: "2020.07"
+    title: "Web制作会社でインターンシップ"
+    description: "HTML・CSSなどの基礎的なコーディングを独学を半年ほどした後、Web制作会社のインターンシップにコーダーとしてJoinしました。"
+  - date: "2021.01"
+    title: "インターンシップ先の制作会社に入社"
+    description: "半年ほどのインターンシップを経て、入社しました。コーディングだけでなく、ディレクションやSNS運用、保守管理などの業務にも携わりました。"
+  - date: "2022.07"
+    title: "個人事業主となる"
+    description: "本業の傍ら、クラウドワークスやランサーズなど副業でWeb制作をしており、個人事業主となりました。"
+    link:
+      url: "https://en-filer.com/"
+      text: "→ enFielr"
+  - date: "2022.08"
+    title: "自社開発の会社へ転職"
+    description: "WordPressテーマやプラグインを開発する会社へエンジニアとしてJoinしました。リモートワークとなったので、通勤時間も勉強できるように。"
+  - date: "現在"
+    title: ""
+    description: ""
+---
+
+# プロフィール
+
+フロントエンドエンジニアとして、モダンなWeb技術を駆使したユーザーエクスペリエンスの向上に取り組んでいます。
+
+## 現在の取り組み
+
+- WordPress開発（業務）
+- モダンフロントエンド技術の習得
+- 個人ブログ運営
+- 技術記事の執筆

--- a/src/content/profile/main.md
+++ b/src/content/profile/main.md
@@ -1,11 +1,14 @@
 ---
 name: "大嶋大輝"
-title: "Frontend Engineer"
-location: "Japan"
-availability: "Available"
+title: "Software Engineer"
+location: "Shimane, Japan"
 avatar: "/images/avatar.png"
-bio: "当サイトをご覧いただきありがとうございます。フロントエンドエンジニアとして活動している大嶋大輝です。業務では WordPress Developer として働き、個人では Next.js や Astro などのモダンな Web 技術に取り組んでいます。趣味は読書で、技術書からビジネス書まで幅広く読んでいます。"
+bio: "教育系ベンチャーでNext.js・TypeScriptを使って開発しているソフトウェアエンジニア。コーヒーを片手にコードを書き、時々キャンプで自然と戯れています。このブログでは開発で躓いたこと、学んだこと、「なるほど！」と思ったことを備忘録として綴っています。"
 skills:
+  - name: "HTML"
+    category: "language"
+  - name: "CSS"
+    category: "language"
   - name: "JavaScript"
     category: "language"
   - name: "TypeScript"
@@ -18,36 +21,30 @@ skills:
     category: "framework"
   - name: "WordPress"
     category: "cms"
-  - name: "TailwindCSS"
+  - name: "Tailwind CSS"
+    category: "styling"
+  - name: "Chakra UI"
     category: "styling"
 timeline:
   - date: "2020.07"
-    title: "Web制作会社でインターンシップ"
-    description: "HTML・CSSなどの基礎的なコーディングを独学を半年ほどした後、Web制作会社のインターンシップにコーダーとしてJoinしました。"
+    title: "Web制作会社でインターンシップ開始"
+    description: "HTML・CSSなどの基礎的なコーディングを独学で半年ほど学習した後、Web制作会社でコーダーとしてインターンシップを開始しました。"
   - date: "2021.01"
     title: "インターンシップ先の制作会社に入社"
-    description: "半年ほどのインターンシップを経て、入社しました。コーディングだけでなく、ディレクションやSNS運用、保守管理などの業務にも携わりました。"
+    description: "半年間のインターンシップを経て正式に入社しました。コーディングだけでなく、ディレクションやSNS運用、保守管理などの幅広い業務に携わりました。"
   - date: "2022.07"
-    title: "個人事業主となる"
-    description: "本業の傍ら、クラウドワークスやランサーズなど副業でWeb制作をしており、個人事業主となりました。"
+    title: "個人事業主として副業開始"
+    description: "本業と並行して、クラウドワークスやランサーズでのWeb制作を開始し、個人事業主として登録しました。"
     link:
       url: "https://en-filer.com/"
       text: "→ enFielr"
   - date: "2022.08"
-    title: "自社開発の会社へ転職"
-    description: "WordPressテーマやプラグインを開発する会社へエンジニアとしてJoinしました。リモートワークとなったので、通勤時間も勉強できるように。"
+    title: "WordPress開発会社へ転職"
+    description: "WordPressテーマやプラグインを開発・販売する会社へWordPress Developerとして転職しました。これまでのテーマを使用する側から、開発・販売する側へとポジションが変わりました。"
+  - date: "2024.04"
+    title: "教育系ベンチャー企業へ転職"
+    description: "モダンな技術スタックを使った開発に携わりたく、AI人材育成と DX を支援する教育系ベンチャー企業へ Software Engineer として転職しました。個人開発で使用していた Next.js や TypeScript を業務でも活用できるようになりました。"
   - date: "現在"
     title: ""
     description: ""
 ---
-
-# プロフィール
-
-フロントエンドエンジニアとして、モダンなWeb技術を駆使したユーザーエクスペリエンスの向上に取り組んでいます。
-
-## 現在の取り組み
-
-- WordPress開発（業務）
-- モダンフロントエンド技術の習得
-- 個人ブログ運営
-- 技術記事の執筆

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ProfileCard from "../components/ProfileCard.astro";
+import Timeline from "../components/Timeline.astro";
 ---
 
 <BaseLayout title="プロフィール | daiblog" description="大嶋大輝のプロフィールページ。フロントエンドエンジニアとしての経歴や技術スタックを紹介しています。">
@@ -13,84 +14,6 @@ import ProfileCard from "../components/ProfileCard.astro";
 		</div>
 
 		<!-- キャリアタイムライン -->
-		<div class="prose max-w-full dark:prose-invert">
-			<h2>Career Timeline</h2>
-			<hr>
-		<ol class="list-none relative border-l border-gray-300">
-			<li class="mb-8 -ml-2">
-				<div
-					class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"
-				>
-				</div>
-				<time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
-					2020.07
-				</time>
-				<h5>Web制作会社でインターンシップ</h5>
-				<p class="mb-4 text-sm text-gray-600">
-					HTML・CSSなどの基礎的なコーディングを独学を半年ほどした後、Web制作会社のインターンシップにコーダーとしてJoinしました。
-				</p>
-			</li>
-			<li class="mb-8 -ml-2">
-				<div
-					class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"
-				>
-				</div>
-				<time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
-					2021.01
-				</time>
-				<h5>インターンシップ先の制作会社に入社</h5>
-				<p class="text-sm text-gray-600">
-					半年ほどのインターンシップを経て、入社しました。コーディングだけでなく、ディレクションやSNS運用、保守管理などの業務にも携わりました。
-				</p>
-			</li>
-			<li class="mb-8 -ml-2">
-				<div
-					class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"
-				>
-				</div>
-				<time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
-					2022.07
-				</time>
-				<h5>個人事業主となる</h5>
-				<p class="text-sm text-gray-600">
-					本業の傍ら、クラウドワークスやランサーズなど副業でWeb制作をしており、個人事業主となりました。<br
-					/>
-					<a
-						href="https://en-filer.com/"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="font-normal"
-					>
-						&rarr; enFielr
-					</a>
-				</p>
-			</li>
-			<li class="mb-8 -ml-2">
-				<div
-					class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"
-				>
-				</div>
-				<time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
-					2022.08
-				</time>
-				<h5>自社開発の会社へ転職</h5>
-				<p class="text-sm text-gray-600">
-					WordPressテーマやプラグインを開発する会社へエンジニアとしてJoinしました。<br
-					/>
-					 リモートワークとなったので、通勤時間も勉強できるように。
-				</p>
-			</li>
-			<li class="mb-8 -ml-2">
-				<div
-					class="absolute w-3 h-3 bg-gray-300 rounded-full mt-2.5 -left-1.5 border border-white"
-				>
-				</div>
-				<time class="font-['Josefin_Sans'] mb-1 text-xs text-gray-400">
-					現在
-				</time>
-			</li>
-		</ol>
-			</div>
-		</div>
+		<Timeline />
 	</div>
 </BaseLayout>

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -6,7 +6,7 @@ import Timeline from "../components/Timeline.astro";
 
 <BaseLayout title="プロフィール | daiblog" description="大嶋大輝のプロフィールページ。フロントエンドエンジニアとしての経歴や技術スタックを紹介しています。">
 	<div class="max-w-4xl mx-auto">
-		<h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-8">Profile</h1>
+		<h1 class="text-3xl text-gray-900 dark:text-white font-['Josefin_Sans'] mb-2">Profile</h1>
 		
 		<!-- プロフィールカード -->
 		<div class="mb-12">


### PR DESCRIPTION
## Summary
Closes #16 (Phase 2)

GitHub Issue #16「簡易プロフィール欄を追加」のPhase 2実装です。

- Markdownベースのコンテンツ管理システムを実装
- ProfileCardコンポーネントをコンテンツ対応に更新  
- Timelineコンポーネントを作成（元UIデザイン維持）
- プロフィールページをコンテンツベースに更新
- プロフィールUIの詳細調整とフォント統一

## Test plan
- [x] ビルドが正常に完了することを確認（46ページ生成成功）
- [x] プロフィールデータがMarkdownファイルから正しく取得されることを確認
- [x] ProfileCardがfull/compact両方で正常表示されることを確認
- [x] Timelineが元UIデザインを維持して表示されることを確認
- [x] 英字テキストのJosefin Sansフォント適用を確認

🤖 Generated with [Claude Code](https://claude.ai/code)